### PR TITLE
Fix Simon Bolivar UTF-8

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1308,7 +1308,7 @@
 	},
 	{
 		"name": "Gran Colombia",
-		"leaderName": "Simon Boli­var",
+		"leaderName": "Simon Bolivar",
 		"adjective": [
 			"Gran Colombian"
 		],


### PR DESCRIPTION
Unciv doesn't seem to present the UTF-8 characters in Simon's name that correctly. This flips it to ASCII.
